### PR TITLE
Add Azure deployment support

### DIFF
--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -1,0 +1,46 @@
+name: Deploy to Azure Web App
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Build Docker image
+        run: |
+          docker build -t $REGISTRY_NAME.azurecr.io/$IMAGE_NAME:$GITHUB_SHA .
+        env:
+          REGISTRY_NAME: ${{ secrets.ACR_NAME }}
+          IMAGE_NAME: dashboardambiental
+
+      - name: Login to Azure Container Registry
+        uses: azure/docker-login@v1
+        with:
+          login-server: ${{ secrets.ACR_NAME }}.azurecr.io
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
+
+      - name: Push image
+        run: |
+          docker push $REGISTRY_NAME.azurecr.io/$IMAGE_NAME:$GITHUB_SHA
+        env:
+          REGISTRY_NAME: ${{ secrets.ACR_NAME }}
+          IMAGE_NAME: dashboardambiental
+
+      - name: Deploy to Azure Web App
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
+          images: ${{ secrets.ACR_NAME }}.azurecr.io/dashboardambiental:$GITHUB_SHA
+          slot-name: Production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Build frontend
+FROM node:18 AS frontend-build
+WORKDIR /app/frontend
+COPY frontend/package*.json ./
+RUN npm install
+COPY frontend/ .
+RUN npm run build
+
+# Build backend
+FROM node:18 AS backend-build
+WORKDIR /app/backend
+COPY backend/package*.json ./
+COPY backend/tsconfig.json ./
+RUN npm install
+COPY backend/ ./
+RUN npm run build
+
+# Production image
+FROM node:18-slim
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=backend-build /app/backend/dist ./dist
+COPY --from=backend-build /app/backend/node_modules ./node_modules
+COPY --from=frontend-build /app/frontend/dist ./dist/public
+COPY backend/package.json ./package.json
+
+EXPOSE 3000
+CMD ["node", "dist/app.js"]

--- a/README.md
+++ b/README.md
@@ -17,3 +17,17 @@ const apiKey = "tu_api_key_aqui";  Por la api que te da Openweather
 
 Ejecutar el backend npm run dev
 
+### Despliegue en Azure
+
+El repositorio incluye un `Dockerfile` y un workflow de GitHub Actions
+(`.github/workflows/azure.yml`) que construye una imagen de Docker y la despliega
+en un **Azure Web App**. Para utilizarlo debes configurar los siguientes
+secretos en tu repositorio:
+
+- `ACR_NAME`, `ACR_USERNAME` y `ACR_PASSWORD`: credenciales de tu Azure
+  Container Registry.
+- `AZURE_WEBAPP_NAME`: nombre de la aplicación Web App que recibirá la imagen.
+
+Al hacer push a la rama `main`, la acción construirá la imagen y la publicará en
+el registro configurado, para luego actualizar la Web App.
+

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "ts-node-dev --respawn --transpile-only src/app.ts"
+    "dev": "ts-node-dev --respawn --transpile-only src/app.ts",
+    "build": "tsc",
+    "start": "node dist/app.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,6 +1,7 @@
 import "dotenv/config";
 import express from "express";
 import cors from "cors";
+import path from "path";
 import { AppDataSource } from "./data-source"; 
 import authRoutes from "./routes/authRoutes";
 import weatherRoutes from "./routes/weatherRoutes";
@@ -13,6 +14,14 @@ app.use(cors());
 app.use(express.json());
 app.use("/api/auth", authRoutes);
 app.use("/api/weather", weatherRoutes);
+
+// Servir archivos estáticos del frontend compilado
+app.use(express.static(path.join(__dirname, "public")));
+
+// Ruta de fallback para aplicaciones SPA
+app.get("*", (_req, res) => {
+  res.sendFile(path.join(__dirname, "public", "index.html"));
+});
 
 // rutas (luego las importas aquí)
 // app.use('/api/auth', authRoutes)


### PR DESCRIPTION
## Summary
- build backend with tsc and expose start script
- serve compiled frontend from Express
- add Dockerfile for building full stack container
- document Azure Web App deployment
- add GitHub Actions workflow to publish container to Azure

## Testing
- `npm --version`
- `npm --prefix backend run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684a06f4e0d48323aa9a3d21b73cf0bd